### PR TITLE
Strict AST

### DIFF
--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -1,3 +1,5 @@
+//! The abstract syntax tree for the Cogs templating language.
+
 #[derive(Debug)]
 pub struct Component {
     pub elements: Vec<Element>,
@@ -19,12 +21,24 @@ pub struct HtmlTag {
 
 #[derive(Debug, Clone)]
 pub struct Attribute {
-    pub name: Element,
-    pub value: Option<Element>,
+    pub name: String,
+    pub value: Option<Expression>,
 }
 
 #[derive(Debug, Clone)]
 pub struct CodeBlock {
     // pub is_async: bool,
-    pub content: Vec<Element>,
+    pub content: Vec<CodeElement>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Expression {
+    Code(String),
+    Text(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum CodeElement {
+    Html(HtmlTag),
+    Code(String)
 }

--- a/crates/codegen/src/generate.rs
+++ b/crates/codegen/src/generate.rs
@@ -42,7 +42,7 @@ fn quoted(s: &str) -> String {
 impl Expression {
     fn append(&self, cx: &mut AppendContext) {
         match self {
-            Expression::Literal(literal) => push!(cx, "\"{}\"", literal),
+            Expression::Text(literal) => push!(cx, "\"{}\"", literal),
             Expression::Code(code) => cx.push_arg(code.trim().to_string()),
         }
     }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1,19 +1,19 @@
 use nom::{
     branch::alt,
     bytes::complete::{is_not, tag, take_while1},
-    character::complete::{char, multispace0, one_of, space0, space1},
+    character::complete::{char, multispace0, space0, space1},
     combinator::{opt, peek},
     error::context,
-    multi::{many0, many1, separated_list0},
-    sequence::{delimited, pair, preceded, terminated, tuple},
-    InputLength,
+    multi::{many0, separated_list0},
+    sequence::{delimited, pair, preceded, tuple},
+    Parser,
 };
 use tracing::debug;
 
 type IResult<I, O> = nom::IResult<I, O, error::Error<I>>;
 use error::Error;
 
-use cogs_ast::{Attribute, CodeBlock, Component, Element, HtmlTag};
+use cogs_ast::{Attribute, CodeBlock, CodeElement, Component, Element, Expression, HtmlTag};
 // reexport for cogs crate
 #[doc(hidden)]
 pub use nom;
@@ -34,12 +34,12 @@ pub fn parse_consecutive_proper_elements(input: &str) -> IResult<&str, Vec<Eleme
 
 fn parse_element(input: &str) -> IResult<&str, Element> {
     let (input, _) = multispace0(input)?;
-    alt((parse_html, context("code block", parse_code_block)))(input)
+    alt((parse_html_tag.map(Element::Html), context("code block", parse_code_block.map(Element::Block))))(input)
 }
 
 fn parse_proper_element(input: &str) -> IResult<&str, Element> {
     // dbg!(&input);
-    let res = alt((parse_element, parse_text))(input);
+    let res = alt((parse_element, parse_text.map(Element::Text)))(input);
     // dbg!(&res);
     res
 }
@@ -56,32 +56,32 @@ fn parse_tag_name(input: &str) -> IResult<&str, &str> {
     take_while1(is_valid_tag_name_char)(input)
 }
 
+fn parse_expression(input: &str) -> IResult<&str, Expression> {
+    alt((
+        delimited(char('{'), is_not("{}"), char('}'))
+            .map(|code: &str| Expression::Code(code.to_string())),
+        delimited(char('"'), is_not("\""), char('"'))
+            .map(|code: &str| Expression::Text(code.to_string())),
+    ))(input)
+}
+
 fn parse_attribute(input: &str) -> IResult<&str, Attribute> {
     // Shouldn't be needed with take_while1, re-add if fail
     /*
     if input.starts_with('>') || input.is_empty() {
         // Return a recoverable error so `separated_list0` stops parsing cleanly
-        return Err(Err::Error(Error::new(input, nom::error::ErrorKind::Eof)));
+        return Err(Error::eof(input));
     }
     */
 
-    let (input, key) = take_while1(is_valid_attr_char)(input)?;
-    let (input, value) = opt(preceded(
-        tuple((tag("="), space0)),
-        delimited(tag("\""), is_not("\""), tag("\"")),
-    ))(input)?;
-
-    let mut resulting_value = None;
-
-    if value.is_some_and(|x| !x.is_empty()) {
-        resulting_value = Some(Element::Text(value.unwrap().to_string()));
-    }
+    let (input, name) = take_while1(is_valid_attr_char)(input)?;
+    let (input, value) = opt(preceded(tuple((tag("="), space0)), parse_expression))(input)?;
 
     Ok((
         input,
         Attribute {
-            name: Element::Text(key.to_string()),
-            value: resulting_value,
+            name: name.to_string(),
+            value,
         },
     ))
 }
@@ -132,7 +132,7 @@ fn parse_html_closing_tag(input: &str) -> IResult<&str, &str> {
     Ok((input, tag))
 }
 
-fn parse_text(input: &str) -> IResult<&str, Element> {
+fn parse_text(input: &str) -> IResult<&str, String> {
     // dbg!(&input);
     let mut index = 0;
     while index < input.len() {
@@ -161,7 +161,7 @@ fn parse_text(input: &str) -> IResult<&str, Element> {
 
     // dbg!(&input[0..index]);
 
-    Ok((&input[index..], Element::Text(input[0..index].to_string())))
+    Ok((&input[index..], input[0..index].to_string()))
 }
 
 fn parse_html_contents(input: &str) -> IResult<&str, Vec<Element>> {
@@ -172,7 +172,7 @@ fn parse_html_contents(input: &str) -> IResult<&str, Vec<Element>> {
     Ok((input, out))
 }
 
-fn parse_html(input: &str) -> IResult<&str, Element> {
+fn parse_html_tag(input: &str) -> IResult<&str, HtmlTag> {
     let (input, _) = multispace0(input)?; // remove spaces when debugging is complete
     let (input, mut htag) = parse_html_opening_tag(input)?;
     let (input, content) = parse_html_contents(input)?; // parse_consecutive_elements(input)?;
@@ -182,47 +182,44 @@ fn parse_html(input: &str) -> IResult<&str, Element> {
     if htag.tag != close_name {
         return Err(Error::custom_failure(
             input,
-            format!("expected closing tag `</{}>`, got `</{}>`", htag.tag, close_name),
+            format!(
+                "expected closing tag `</{}>`, got `</{}>`",
+                htag.tag, close_name
+            ),
         ));
     }
 
-    Ok((input, Element::Html(htag)))
+    Ok((input, htag))
 }
 
-/*
-fn parse_code_until_interrupted(input: &str) -> IResult<&str, Element> {
-    let (input, code) = pair(is_not("{};"), one_of("{};"))(input)?;
-
-    Ok((
-        input,
-        Element::Text(format!("{}{}", code.0, code.1))
-    ))
+fn parse_code_element(input: &str) -> IResult<&str, CodeElement> {
+    alt((
+        parse_html_tag.map(CodeElement::Html),
+        parse_text.map(CodeElement::Code)
+    ))(input)
 }
-*/
 
-fn parse_inside_code_block(input: &str) -> IResult<&str, Vec<Element>> {
+fn parse_code_elements(input: &str) -> IResult<&str, Vec<CodeElement>> {
     debug!("Attempting inside code block {input}");
-    let (input, elems) = parse_consecutive_proper_elements(input)?;
+
+    let (input, _) = multispace0(input)?;
+    let (input, elems) = many0(parse_code_element)(input)?;
 
     debug!(?elems, "parsed inside code block");
     Ok((input, elems))
 }
 
-fn parse_code_block(input: &str) -> IResult<&str, Element> {
+fn parse_code_block(input: &str) -> IResult<&str, CodeBlock> {
     if input.chars().nth(0) == Some('{') {
         debug!("Attempting code block on {input}");
     }
-    let (input, content) = delimited(
-        char('{'),
-        parse_inside_code_block, // get here eventually, currently code blocks do not work at all.
-        char('}'),
-    )(input)?;
+    let (input, content) = delimited(char('{'), parse_code_elements, char('}'))(input)?;
 
     Ok((
         input,
-        Element::Block(CodeBlock {
+        CodeBlock {
             // is_async: is_async.unwrap_or(false),
             content,
-        }),
+        },
     ))
 }

--- a/examples/small_axum/build.rs
+++ b/examples/small_axum/build.rs
@@ -1,3 +1,4 @@
 fn main() {
+    let _ = cogs::init_tracing();
     cogs::build(std::env::current_dir().unwrap().join("cogs")).unwrap();
 }

--- a/examples/small_axum/cogs/index.cog
+++ b/examples/small_axum/cogs/index.cog
@@ -1,4 +1,7 @@
-{ let random: u32 = rand::random(); }
+{
+  let random: u32 = rand::random();
+  let random_p: u8 = rand::random();
+}
 <html>
   <head>
     <title>cogs - small_to_console</title>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub fn parse_cog(input: String, file: &str) -> eyre::Result<cogs_ast::Component>
             if leftover.is_empty() {
                 Ok(ast)
             } else {
-                Err(eyre::eyre!("Not all input parsed, leftover: {leftover}"))
+                Err(eyre::eyre!("Not all input parsed, leftover: {leftover}; parsed ast: {ast:#?}"))
             }
         }
         Err(error) => {


### PR DESCRIPTION
Narrows down the AST so that:
- attribute name is now String
- attribute value is now only code or text (no more html)
- code block elements are now either `Code(String)` or `Html(HtmlTag)`